### PR TITLE
fix: Cannot use object of type Mcpuishor\QdrantLaravel\DTOs\Vector as array

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -38,9 +38,7 @@ class Schema
     {
         if ( $vectors instanceof Vector ) {
             $this->validateVectorParameters($vectors->toArray());;
-        }
-
-        if (isset($vectors['distance'])) {
+        } else if (isset($vectors['distance'])) {
             //we're in single vector mode
             $this->validateVectorParameters($vectors);
         } else {


### PR DESCRIPTION
PHP 8.4
Laravel 12


I was getting this error when I tried creating a schema following the readme.
I was passing a Vector object to the $vectors argument.